### PR TITLE
Erase previous coverage data

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
 setenv =
     COVERAGE_PROCESS_START={toxinidir}/tox.ini
 commands =
+    coverage erase
     coverage run -m zope.testrunner --test-path=src []
     coverage combine
     coverage html


### PR DESCRIPTION
Without using the `erase` command, it was possible that one got wrong
results, as coverage data from previous runs could have been used.

modified:   tox.ini